### PR TITLE
Fix error message grabbing

### DIFF
--- a/src/postgres-connection.cpp
+++ b/src/postgres-connection.cpp
@@ -271,9 +271,10 @@ namespace db {
       pgconn_ = PQconnectdb(connInfo == nullptr ? "" : connInfo);
       
       if( PQstatus(pgconn_) != CONNECTION_OK ) {
+        std::string errorMessage { PQerrorMessage(pgconn_) };
         PQfinish(pgconn_);
         pgconn_ = nullptr;
-        throw ConnectionException(std::string(PQerrorMessage(pgconn_)));
+        throw ConnectionException(errorMessage);
       }
 
       return *this;


### PR DESCRIPTION
The connection error message was always "NULL connection pointer" since
the libpq connection handle was set to null before reading the error
message.

This patch use a temporary std::string to read the error message before
clearing the connection handle.